### PR TITLE
Fix typo in unit test name

### DIFF
--- a/Tests/CK.MicroBenchmark.Tests/MicroBenchmarkTests.cs
+++ b/Tests/CK.MicroBenchmark.Tests/MicroBenchmarkTests.cs
@@ -38,7 +38,7 @@ namespace CK.MicroBenchmark.Tests
         }
 
         [Test]
-        public void Benchmarking_CPU_is_less_precise_that_time()
+        public void Benchmarking_CPU_is_less_precise_than_time()
         {
             int Fib( int n )
             {


### PR DESCRIPTION
Just fixed a dumb typo in a unit test name. 

I find the name of this test still weird though. It says that _CPU measure_ should be less precise ~that~ than _Time measure_ but the code does not actually compare CPU vs Time. I guess it was kind of visual assertion, and it would be tedious to write a test that pass reliably ... but still I find it funny.